### PR TITLE
Backport r39378 to fix at_exit hooks with rescue behavior.

### DIFF
--- a/eval_jump.c
+++ b/eval_jump.c
@@ -99,6 +99,8 @@ rb_exec_end_proc(void)
     struct end_proc_data *volatile link;
     int status;
     volatile int safe = rb_safe_level();
+    rb_thread_t *th = GET_THREAD();
+    VALUE errinfo = th->errinfo;
 
     while (ephemeral_end_procs) {
 	link = ephemeral_end_procs;
@@ -112,6 +114,7 @@ rb_exec_end_proc(void)
 	POP_TAG();
 	if (status) {
 	    error_handle(status);
+      if (!NIL_P(th->errinfo)) errinfo = th->errinfo;
 	}
 	xfree(link);
     }
@@ -128,10 +131,12 @@ rb_exec_end_proc(void)
 	POP_TAG();
 	if (status) {
 	    error_handle(status);
+      if (!NIL_P(th->errinfo)) errinfo = th->errinfo;
 	}
 	xfree(link);
     }
     rb_set_safe_level_force(safe);
+    th->errinfo = errinfo;
 }
 
 void

--- a/test/ruby/test_beginendblock.rb
+++ b/test/ruby/test_beginendblock.rb
@@ -145,4 +145,17 @@ EOW
     assert_in_out_err(t.path, "", expected, [], "[ruby-core:35237]")
     t.close
   end
+
+  def test_rescue_at_exit
+    bug5218 = '[ruby-core:43173][Bug #5218]'
+    cmd = [
+      "raise 'X' rescue nil",
+      "nil",
+      "exit(42)",
+    ]
+    %w[at_exit END].each do |ex|
+      out, err, status = EnvUtil.invoke_ruby(cmd.map {|s|["-e", "#{ex} {#{s}}"]}.flatten, "", true, true)
+      assert_equal(["", "", 42], [out, err, status.exitstatus], "#{bug5218}: #{ex}")
+    end
+  end
 end


### PR DESCRIPTION
```
Fri Feb 22 14:28:17 2013  Nobuyoshi Nakada  <nobu@ruby-lang.org>

    * eval_jump.c (rb_exec_end_proc): remember the latest exit status.
      [ruby-core:43173][Bug #5218]
```

ref: http://bugs.ruby-lang.org/projects/ruby-193/repository/revisions/39378/diff

This is currently causing CI to outright lie for some of our apps.
